### PR TITLE
Update treeherder-client from 1.7.0 to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ click==4.1
 Flask==0.10.1
 gprof2dot==2015.2.3
 gunicorn==19.3.0
-httplib2==0.9.1
 ijson==2.2
 itsdangerous==0.24
 Jinja2==2.7.3
@@ -12,14 +11,20 @@ keyring==5.4
 lpthw.web==1.1
 MarkupSafe==0.23
 mozci==0.14.0
-oauth2==1.5.211
 progressbar==2.3
 PyHawk-with-a-single-extra-commit==0.1.5
 redis==2.10.3
 requests==2.7.0
 rq==0.5.4
 taskcluster==0.0.24
-treeherder-client==1.7.0
 uWSGI==2.0.11.1
 Werkzeug==0.10.4
 wheel==0.24.0
+
+# Required by mozci
+treeherder-client==2.0.1
+
+# Required by treeherder-client
+mohawk==0.3.1
+requests-hawk==1.0.0
+six==1.10.0


### PR DESCRIPTION
It now requires mohawk/requests-hawk/six, and no longer requires oauth2 and httplib2. The sub-dependencies have been separated to make it easier to spot orphaned dependencies in the future (treeherder-client isn't used directly by try_extender, but via mozci).
